### PR TITLE
update olog URL preferences

### DIFF
--- a/preferences/pref.ini
+++ b/preferences/pref.ini
@@ -47,12 +47,12 @@ org.csstudio.display.builder.model/font_files=/opt/eic-phoebus-resources/prefere
 org.csstudio.display.builder.model/color_files=/opt/eic-phoebus-resources/preferences/preferences/phoebus_color.def
 
 # Alarm server
-org.phoebus.applications.alarm/server=epics-services-acc.nsls2.bnl.gov:40094
-org.phoebus.applications.alarm/config_name=NSLS2_OPR
-org.phoebus.applications.alarm/config_names=NSLS2_OPR
+org.phoebus.applications.alarm/server=demo01.eic.bnl.gov:40094
+org.phoebus.applications.alarm/config_name=EIC
+org.phoebus.applications.alarm/config_names=EIC
 
 # Alarm logging
-org.phoebus.applications.alarm.logging.ui/service_uri=http://localhost:8080
+org.phoebus.applications.alarm.logging.ui/service_uri=http://demo01.eic.bnl.gov:8080
 
 org.phoebus.applications.alarm.logging.ui/es_host=es01.cs.nsls2.local
 org.phoebus.applications.alarm.logging.ui/es_port=9201
@@ -60,10 +60,10 @@ org.phoebus.applications.alarm.logging.ui/es_index=nsls2_opr
 org.phoebus.applications.alarm.logging.ui/es_max_size=1000
 
 # Logbook
-org.phoebus.logbook/logbook_factory=olog
+org.phoebus.logbook/logbook_factory=olog-es
 
 # Olog
-org.phoebus.olog.api/olog_url=https://web02.cs.nsls2.local:8181/Olog/resources
+org.phoebus.olog.es.api/olog_url=http://demo03.eic.bnl.gov:40080/Olog
 
 # Channelfinder
 org.phoebus.channelfinder/serviceURL=https\://es01.cs.nsls2.local:8181/ChannelFinder/


### PR DESCRIPTION
updating some of the Phoebus preferences to point to the new Phoebus Olog deployment
webclient:
http://demo03.eic.bnl.gov:3000/
